### PR TITLE
Feat: add GitHub Actions workflow for publishing wheel releases

### DIFF
--- a/.github/workflows/gen_dist.yml
+++ b/.github/workflows/gen_dist.yml
@@ -1,0 +1,39 @@
+name: Publish Wheel to Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  upload-release-asset:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Instalar o python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Instalar o zip
+        run: choco install zip -y
+
+      - name: Instalar o poetry
+        run: pipx install poetry
+
+      - name: Instalar dependências
+        run: poetry install
+
+      - name: Build .whl file
+        run: poetry build -f wheel
+
+      - name: Create Release with GitHub CLI
+        shell: bash
+        run: |
+          FILES_WHEEL=$(ls ./dist/*.whl)
+          gh release create ${{ github.ref_name }} $FILES_WHEEL --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run_test_coverage.yml
+++ b/.github/workflows/run_test_coverage.yml
@@ -1,67 +1,67 @@
-name: Coverage CI  
-on: [pull_request]  
-  
-jobs:  
-  poetry:  
-    runs-on: ubuntu-latest  
-    defaults:  
-      run:  
-        shell: bash  
-  
-    strategy:  
+name: Coverage CI
+on: [pull_request]
+
+jobs:
+  poetry:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
       max-parallel: 42   # specify the maximum number of jobs that can run concurrently
-      fail-fast: false  
-      matrix:  
-        python-version: ["3.10"]  
-  
-    steps:  
-      #----------------------------------------------  
-      #       check-out repo and set-up python  
-      #----------------------------------------------  
-      - name: Check out repository  
-        uses: actions/checkout@v3  
-      - name: Set up python  
-        id: setup-python  
-        uses: actions/setup-python@v4  
-        with:  
-          python-version: ${{ matrix.python-version }}  
-  
-      #----------------------------------------------  
-      #       install & configure poetry  
-      #----------------------------------------------  
-      - name: Install and configure Poetry  
-        uses: snok/install-poetry@v1  
-        with:  
-          virtualenvs-create: true  
-          virtualenvs-in-project: true  
-  
-      #----------------------------------------------  
-      #       load cached venv if cache exists  
-      #----------------------------------------------  
-      - name: Load cached venv  
-        id: cached-poetry-dependencies  
-        uses: actions/cache@v3  
-        with:  
-          path: .venv  
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}  
-  
-      #----------------------------------------------  
-      #       install dependencies if cache does not exist  
-      #----------------------------------------------  
-      - name: Install dependencies  
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'  
-        run: poetry install --verbose --no-interaction
-  
-      #----------------------------------------------  
-      #       install your root project, if required  
-      #----------------------------------------------  
-      - name: Install project  
-        run: poetry install --verbose --no-interaction  
-  
-      #----------------------------------------------  
-      #       Test coverage  
-      #----------------------------------------------  
-      - name: Run tests and generate coverage  
-        run: |  
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      #----------------------------------------------
+      #       install & configure poetry
+      #----------------------------------------------
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      #----------------------------------------------
+      #       install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --verbose --no-interaction --all-groups --all-extras
+
+      #----------------------------------------------
+      #       install your root project, if required
+      #----------------------------------------------
+      - name: Install project
+        run: poetry install --verbose --no-interaction --all-groups --all-extras
+
+      #----------------------------------------------
+      #       Test coverage
+      #----------------------------------------------
+      - name: Run tests and generate coverage
+        run: |
           poetry run task test
           poetry run task test-badge


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of Python wheel files upon the creation of a new release tag. The most important changes include setting up the workflow configuration and defining the necessary steps to build and upload the wheel file.

New GitHub Actions workflow:

* [`.github/workflows/gen_dist.yml`](diffhunk://#diff-d4d95fc6a66f5336805cac9bd40602a9c285ed69d01e4cc789ca58600fdd7958R1-R39): Added a new workflow named "Publish Wheel to Release" that triggers on push events to tags matching the pattern "v*". The workflow includes steps to check out the repository, set up Python, install dependencies, build the wheel file, and create a release using the GitHub CLI.